### PR TITLE
[PR] Alter the SDK URL used for embedding Facebook posts

### DIFF
--- a/includes/wsu-embed-facebook-post.php
+++ b/includes/wsu-embed-facebook-post.php
@@ -48,7 +48,7 @@ class WSU_Embed_Facebook {
 			}
 		}
 
-		wp_register_script( 'facebook-api', 'https://connect.facebook.net/en_US/all.js#xfbml=1&version=v2.3' );
+		wp_register_script( 'facebook-api', 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.0' );
 		wp_enqueue_script( 'facebook-api' );
 
 		$out = '<div id="fb-root"></div>';


### PR DESCRIPTION
the all.js is giving us issues in production, try sdk.js and an
older version (2.0)