### PR TITLE
[PR] Responsive wrapper for YouTube embeds

### DIFF
--- a/includes/wsu-embed-youtube.php
+++ b/includes/wsu-embed-youtube.php
@@ -296,9 +296,9 @@ function youtube_id( $url ) {
 	}
 
 	if ( ( isset( $url['path'] ) && '/videoseries' == $url['path'] ) || isset( $qargs['list'] ) ) {
-		$html = "<span class='embed-youtube' style='$alignmentcss display: block;'><iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/videoseries?list=$id&hl=en_US" ) ) . "' frameborder='0' allowfullscreen='true'></iframe></span>";
+		$html = "<div class='embed-youtube' style='$alignmentcss display: block;'><iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/videoseries?list=$id&hl=en_US" ) ) . "' frameborder='0' allowfullscreen='true'></iframe></div>";
 	} else {
-		$html = "<span class='embed-youtube' style='$alignmentcss display: block;'><iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/$id?version=3&rel=$rel&fs=1$fmt$autohide&showsearch=$search&showinfo=$info&iv_load_policy=$iv$start$end$hd&wmode=$wmode$theme$autoplay{$cc}{$cc_lang}" ) ) . "' frameborder='0' allowfullscreen='true'></iframe></span>";
+		$html = "<div class='embed-youtube' style='$alignmentcss display: block;'><iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/$id?version=3&rel=$rel&fs=1$fmt$autohide&showsearch=$search&showinfo=$info&iv_load_policy=$iv$start$end$hd&wmode=$wmode$theme$autoplay{$cc}{$cc_lang}" ) ) . "' frameborder='0' allowfullscreen='true'></iframe></div>";
 	}
 
 	/**


### PR DESCRIPTION
Fixes #30 

Using the same classes (to hopefully preserve any custom styles people might have in place) but changing the span to a div (to prevent wrapping by paragraph tags), the following rules would give us responsive videos:

```
.embed-youtube {
	height: 0;
	margin-bottom: 1em;
	padding-bottom: 56.25%;
	position: relative;
}

.embed-youtube .youtube-player {
	height: 100%;
	left: 0;
	position: absolute;
	top: 0;
	width: 100%;
}
```

Would the Spine parent theme be the most appropriate place to add these?

@jeremyfelt Let me know what you think! If it looks like a good way to go, #reviewmerge?