### PR TITLE
fix google maps shortcode not displaying

### DIFF
--- a/includes/wsu-embed-google-maps.php
+++ b/includes/wsu-embed-google-maps.php
@@ -31,14 +31,14 @@ function wsu_googlemaps_embed_to_short_code_callback( $match ) {
 
 	if ( preg_match( '/\bwidth=[\'"](\d+)(%)?/', $match[0], $width ) ) {
 		$percent = ! empty( $width[2] ) ? '%' : '';
-		$width = absint( $width[1] ) . $percent;
+		$width   = absint( $width[1] ) . $percent;
 	} else {
 		$width = 425;
 	}
 
 	if ( preg_match( '/\bheight=[\'"](\d+)(%)?/', $match[0], $height ) ) {
 		$percent = ! empty( $height[2] ) ? '%' : '';
-		$height = absint( $height[1] ) . $percent;
+		$height  = absint( $height[1] ) . $percent;
 	} else {
 		$height = 350;
 	}
@@ -67,7 +67,7 @@ function wsu_googlemaps_shortcode( $atts ) {
 
 	$params = ltrim( $atts[0], '=' );
 
-	$width = 425;
+	$width  = 425;
 	$height = 350;
 
 	if ( preg_match( '!^https?://(www|maps|mapsengine)\.google(\.co|\.com)?(\.[a-z]+)?/.*?(\?.+)!i', $params, $match ) ) {
@@ -83,10 +83,10 @@ function wsu_googlemaps_shortcode( $atts ) {
 		foreach ( (array) $arg as $key => $value ) {
 			if ( 'w' == $key ) {
 				$percent = ( '%' == substr( $value, -1 ) ) ? '%' : '';
-				$width = (int) $value . $percent;
+				$width   = (int) $value . $percent;
 			} elseif ( 'h' == $key ) {
 				$height = (int) $value;
-			} elseif ( 'https://www_google_com/maps/embed?pb' === $key ) {
+			} else {
 				// Replace any spaces in the URL with +, otherwise the embed will break.
 				$value = preg_replace( '/\s+/', '+', $value );
 
@@ -103,7 +103,7 @@ function wsu_googlemaps_shortcode( $atts ) {
 				$key = str_replace( '_', '.', $key );
 
 				// Phew.
-				$url .= "$key=$value";
+				$url .= esc_attr( "$key=$value&amp;" );
 			}
 		}
 		$url = substr( $url, 0, -5 );


### PR DESCRIPTION
The `$url = substr( $url, 0, -5 );` on line 109 was breaking the Google Maps URL, because line 106 did not have `&amp;` appended to it. So I put that in line 106. 

I also changed the elseif on line 89 to allow for other types of Google Maps URLs (this is how the Jetpack plugin does it). We had a user who wanted to embed a custom map, whose URL was formatted like " https://www.google.com/maps/d/embed", and since that didn't meet the condition on line 89, so the plugin had been converting the <iframe> to a [googlemaps] shortcode but not rendering the URL